### PR TITLE
[ `Sentencepiece`]  Fix fast tokenizers sentencepiece issues.

### DIFF
--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -508,17 +508,26 @@ class SpmConverter(Converter):
 
         return tokenizer
 
+    # def normalizer(self, proto):
+    #     precompiled_charsmap = proto.normalizer_spec.precompiled_charsmap
+    #     if not precompiled_charsmap:
+    #         return normalizers.Sequence([normalizers.Replace(Regex(" {2,}"), " ")])
+    #     else:
+    #         return normalizers.Sequence(
+    #             [normalizers.Precompiled(precompiled_charsmap), normalizers.Replace(Regex(" {2,}"), " ")]
+    #         )
+
     def normalizer(self, proto):
-        precompiled_charsmap = proto.normalizer_spec.precompiled_charsmap
-        if not precompiled_charsmap:
-            return normalizers.Sequence([normalizers.Replace(Regex(" {2,}"), " ")])
-        else:
-            return normalizers.Sequence(
-                [normalizers.Precompiled(precompiled_charsmap), normalizers.Replace(Regex(" {2,}"), " ")]
-            )
+        return normalizers.Sequence(
+            [
+                normalizers.Replace(pattern=" ", content="▁"),
+            ]
+        )
 
     def pre_tokenizer(self, replacement, add_prefix_space):
-        return pre_tokenizers.Metaspace(replacement=replacement, add_prefix_space=add_prefix_space)
+        pre_tokenizer = pre_tokenizers.Metaspace(replacement=replacement, add_prefix_space=add_prefix_space)
+        pre_tokenizer.legacy = self.original_tokenizer.legacy
+        return pre_tokenizer
 
     def post_processor(self):
         return None
@@ -1183,13 +1192,14 @@ class LlamaConverter(SpmConverter):
     def normalizer(self, proto):
         return normalizers.Sequence(
             [
-                normalizers.Prepend(prepend="▁"),
                 normalizers.Replace(pattern=" ", content="▁"),
             ]
         )
 
     def pre_tokenizer(self, replacement, add_prefix_space):
-        return None
+        pre_tokenizer = pre_tokenizers.Metaspace(replacement=replacement, add_prefix_space=add_prefix_space)
+        pre_tokenizer.legacy = self.original_tokenizer.legacy
+        return pre_tokenizer
 
     def post_processor(self):
         # 3 possible case :

--- a/src/transformers/models/llama/tokenization_llama_fast.py
+++ b/src/transformers/models/llama/tokenization_llama_fast.py
@@ -117,6 +117,7 @@ class LlamaTokenizerFast(PreTrainedTokenizerFast):
         add_bos_token=True,
         add_eos_token=False,
         use_default_system_prompt=True,
+        legacy=True,
         **kwargs,
     ):
         super().__init__(
@@ -129,6 +130,7 @@ class LlamaTokenizerFast(PreTrainedTokenizerFast):
             use_default_system_prompt=use_default_system_prompt,
             **kwargs,
         )
+        self.legacy = True
         self._add_bos_token = add_bos_token
         self._add_eos_token = add_eos_token
         self.update_post_processor()

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1176,26 +1176,11 @@ class SpecialTokensMixin:
 
     @additional_special_tokens.setter
     def additional_special_tokens(self, value):
-        if self._additional_special_tokens is not None:
-            updated_tokens = []
-            for token in self._additional_special_tokens:
-                if (token not in value or str(token) not in value) and str(token) not in self.special_tokens_map.values():
-                    token.special = False
-                    updated_tokens.append(token)
-            self.add_tokens(updated_tokens)
-        updated_tokens = []
+        # this is going to be deprecated.
         self._additional_special_tokens = [] if value is not None else None
-        # 1. we are resetting the tokens that should not be special
-        # 2. The new additional special tokens should also be updated
         if value is not None:
             for token in value:
-                if str(token) not in self.special_tokens_map.values() and self.is_fast:
-                    self._additional_special_tokens.append(token)
-                else:
-                    updated_tokens.append(token)
-
-        # 3. Add everything to the tokenizer to overwrite
-        self.add_tokens(updated_tokens, True)
+                self._additional_special_tokens.append(token)
 
     @property
     def bos_token_id(self) -> Optional[int]:
@@ -2182,6 +2167,8 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         init_kwargs["name_or_path"] = pretrained_model_name_or_path
 
         additional_special_tokens = init_kwargs.pop("additional_special_tokens", None) or []
+        # The additional special tokens will be added if they don't exist. Only saved as init_kwargs not added_tokens anymore
+
         added_tokens_decoder = {}
         legacy_saved = "added_tokens_decoder" not in init_kwargs
         if not legacy_saved:


### PR DESCRIPTION
# What does this PR do?

Will need the next release of tokenizers.
This is what it will allows us to do:
```python 
from transformers import AutoTokenizer

tok = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf", use_fast = True, from_slow = True, legacy = True)
print(tok.tokenize("Hey <s>. how are you"))
tok = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf", use_fast = True, from_slow = True, legacy = False)
print(tok.tokenize("Hey <s>. how are you"))
```
```python 
['▁Hey', '▁', '<s>', '▁.', '▁how', '▁are', '▁you']
['▁Hey', '▁', '<s>', '.', '▁how', '▁are', '▁you']
```
The extra space that was always added to the eos is now gone. 
This is fully backward compatible and can be saved / push to the hub. The metaspace rust object was not broken, and the argument can also be easily set `tok._tokenizer.pre_tokenizer.legacy = legacy`. 